### PR TITLE
Cleanup permissions and add Shizuku service check (Fixes #1, #2)

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Shizuku Sleep
+Screen Lock

--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ASMSmaliIdeaPluginConfiguration">
     <asm skipDebug="true" skipFrames="true" skipCode="false" expandFrames="false" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,16 +33,13 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
 }
 
 dependencies {
-
     implementation(libs.rikka.shizuku.api)
     implementation(libs.rikka.shizuku.provider)
-//    implementation(libs.androidx.core.ktx)
-//    implementation(libs.androidx.appcompat)
-//    implementation(libs.material)
-//    testImplementation(libs.junit)
-//    androidTestImplementation(libs.androidx.junit)
-//    androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,8 +8,6 @@
     <uses-permission
         android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,13 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission
-        android:name="android.permission.INTERACT_ACROSS_USERS_FULL"
-        tools:ignore="ProtectedPermissions" />
-    <uses-permission
-        android:name="android.permission.WRITE_SECURE_SETTINGS"
-        tools:ignore="ProtectedPermissions" />
-
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/tiendnm/zukulock/SleepService.kt
+++ b/app/src/main/java/com/tiendnm/zukulock/SleepService.kt
@@ -5,13 +5,18 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.IBinder
 import android.util.Log
+import android.widget.Toast
 import rikka.shizuku.Shizuku
 
 class SleepService : Service() {
 
-    private val REQUEST_CODE: Int = 0;
+    private val REQUEST_CODE: Int = 0
 
     private fun checkPermission(code: Int): Boolean {
+        if (!Shizuku.pingBinder()) {
+            Toast.makeText(this, "Shizuku service is not running", Toast.LENGTH_LONG).show()
+            return false
+        }
         if (Shizuku.isPreV11()) {
             // Pre-v11 is unsupported
             return false
@@ -29,8 +34,9 @@ class SleepService : Service() {
             return false
         }
     }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val check = checkPermission(REQUEST_CODE);
+        val check = checkPermission(REQUEST_CODE)
         if (check) {
             runShellCommand()
         }
@@ -38,9 +44,10 @@ class SleepService : Service() {
 
         return START_NOT_STICKY
     }
+
     private fun runShellCommand() {
         try {
-            ShizukuHelper.useNewProcess( arrayOf("input", "keyevent", "26"), null, null)
+            ShizukuHelper.useNewProcess(arrayOf("input", "keyevent", "26"), null, null)
         } catch (e: Exception) {
             Log.e("ShizukuShell", "Error running shell command", e)
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,5 +19,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "Shizuku Sleep"
+rootProject.name = "Screen Lock"
 include(":app")


### PR DESCRIPTION
### Summary

This PR addresses two main issues:

1. **Permission cleanup** (Fixes #1)
   - Removed `SYSTEM_ALERT_WINDOW` and `INTERNET` permissions, which are not required.

2. **Shizuku service check** (#2)
   - Added a runtime check using `Shizuku.pingBinder()` to ensure the Shizuku service is running before executing commands.
   - Shows a user-facing toast message if the service is not active.

### Additional Changes
- Disabled `dependencyInfo` block in `build.gradle` to comply with IzzyOnDroid’s requirement to avoid Google-only BLOBs.
